### PR TITLE
[feat] Add customizable endpoint for GIACT

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To set up your API keys, use the configuration helper like this:
 GiactVerification.configure do |config|
   config.api_username = 'foo'
   config.api_password = 'bar'
-  config.sandbox_mode = false
+  config.sandbox_mode = false #optional
+  config.giact_uri = 'http://custom.giact.api.com/foo/bar' #optional
 end
 ```
 Setting `config.sandbox_mode = true` will post all requests to GIACT's sandbox API.

--- a/lib/giact_verification.rb
+++ b/lib/giact_verification.rb
@@ -19,7 +19,7 @@ module GiactVerification
       :servicing?,
       :accepts_id_type?,
       :valid_account_type?,
-      :giact_uri
+      :giact_endpoint
   end
 
   def self.ready_for_request?

--- a/lib/giact_verification/configuration.rb
+++ b/lib/giact_verification/configuration.rb
@@ -5,6 +5,7 @@ module GiactVerification
     attr_accessor :api_username
     attr_accessor :api_password
     attr_accessor :sandbox_mode
+    attr_accessor :giact_uri
 
     attr_reader :serviced_states, :serviced_countries, :valid_alternative_id_types, :valid_account_types
 
@@ -17,8 +18,10 @@ module GiactVerification
       @valid_account_types        = YAML.load_file(GiactVerification.config_directory + '/valid_account_types.yml')
     end
 
-    def giact_uri
-      if sandbox_mode
+    def giact_endpoint
+      if giact_uri
+        URI.parse(giact_uri)
+      elsif sandbox_mode
         URI.parse('https://sandbox.api.giact.com/verificationservices/v5/InquiriesWS-5-8.asmx').freeze
       else
         URI.parse('https://api.giact.com/verificationservices/v5/InquiriesWS-5-8.asmx').freeze

--- a/lib/giact_verification/request.rb
+++ b/lib/giact_verification/request.rb
@@ -8,7 +8,7 @@ module GiactVerification
     end
 
     def initialize(args)
-      @endpoint = GiactVerification.giact_uri
+      @endpoint = GiactVerification.giact_endpoint
       @body     = args[:body]
     end
 

--- a/spec/acceptance/adding_configuration_spec.rb
+++ b/spec/acceptance/adding_configuration_spec.rb
@@ -5,10 +5,14 @@ describe 'configuring the gem' do
     GiactVerification.configure do |config|
       config.api_username = 'smetz'
       config.api_password = 'bikes4life'
+      config.sandbox_mode = true
+      config.giact_uri    = 'www.giact.sandbox.com'
     end
 
     expect(GiactVerification.configuration.api_username).to eq('smetz')
     expect(GiactVerification.configuration.api_password).to eq('bikes4life')
+    expect(GiactVerification.configuration.sandbox_mode).to eq(true)
+    expect(GiactVerification.configuration.giact_uri).to eq('www.giact.sandbox.com')
 
     reset_config!
   end

--- a/spec/giact_verification/configuration_spec.rb
+++ b/spec/giact_verification/configuration_spec.rb
@@ -39,12 +39,12 @@ describe GiactVerification::Configuration do
     reset_config!
   end
 
-  describe '#giact_uri' do
+  describe '#giact_endpoint' do
     it 'should return the real URI if not in sandbox mode' do
       config = GiactVerification::Configuration.new
       config.sandbox_mode = false
 
-      expect(config.giact_uri.host).to eq('api.giact.com')
+      expect(config.giact_endpoint.host).to eq('api.giact.com')
 
       reset_config!
     end
@@ -53,7 +53,16 @@ describe GiactVerification::Configuration do
       config = GiactVerification::Configuration.new
       config.sandbox_mode = true
 
-      expect(config.giact_uri.host).to eq('sandbox.api.giact.com')
+      expect(config.giact_endpoint.host).to eq('sandbox.api.giact.com')
+
+      reset_config!
+    end
+
+    it 'should return the passed in URI if a giact_uri is passed in' do
+      config = GiactVerification::Configuration.new
+      config.giact_uri = 'https://custom.giact.com/foo'
+
+      expect(config.giact_endpoint.host).to eq('custom.giact.com')
 
       reset_config!
     end


### PR DESCRIPTION
* The idea behind this feature is to allow users to point the gem at any
giact endpoint. This insulates users from updates to the endpoint on
GIACT's side. Say they go from 8.4 to 8.5 and the URL changes. Users can
now add the 8.5 URL directly instead of waiting for the gem to be
upgraded.