### PR TITLE
Add specific gem versions to the .gemspec file

### DIFF
--- a/giact_verification.gemspec
+++ b/giact_verification.gemspec
@@ -29,14 +29,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "dry-validation"
-  spec.add_runtime_dependency "nori"
-  spec.add_runtime_dependency "nokogiri"
+  spec.add_runtime_dependency "dry-validation", "~> 0.11.1"
+  spec.add_runtime_dependency "nori", "~> 2.6.0"
+  spec.add_runtime_dependency "nokogiri", "~> 1.8.2"
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "webmock"
-  spec.add_development_dependency "sinatra"
+  spec.add_development_dependency "bundler", "~> 1.16.1"
+  spec.add_development_dependency "rake", "~> 12.3.0"
+  spec.add_development_dependency "rspec", "~> 3.7.0"
+  spec.add_development_dependency "pry", "~> 0.11.3"
+  spec.add_development_dependency "webmock", "~> 3.3.0"
+  spec.add_development_dependency "sinatra", "~> 2.0.0"
 end


### PR DESCRIPTION
* In response to a warning from bundler, this commit specifies versions
for all gems dependencies.